### PR TITLE
stacks: change stack images to be built on UBI 8.2

### DIFF
--- a/stacks/ubi8-minimal/base/Dockerfile
+++ b/stacks/ubi8-minimal/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
 
 ARG cnb_uid=1000
 ARG cnb_gid=1001

--- a/stacks/ubi8/base/Dockerfile
+++ b/stacks/ubi8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi:8.2
 
 ARG cnb_uid=1000
 ARG cnb_gid=1001


### PR DESCRIPTION
Red Hat product images will no longer be published with the 'latest' tag.
This commit pins our dependency to version 8.2.

Fixes: https://github.com/boson-project/buildpacks/issues/14