### PR TITLE
buildpacks(node): bump dependency on faas-js-runtime

### DIFF
--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,8 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "@redhat/faas-js-runtime": "0.2.0",
-    "cloudevents-sdk": "v1.0.0",
+    "@redhat/faas-js-runtime": "0.2.1",
     "overload-protection": "^1.1.0"
   },
   "devDependencies": {

--- a/buildpacks/nodejs/runtime/server.js
+++ b/buildpacks/nodejs/runtime/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const framework = require('@redhat/faas-js-runtime');
+const ON_DEATH = require('death')({ uncaughtException: true });
 
 const functionPath = process.env.FUNCTION_PATH || '../';
 const LISTEN_PORT = process.env.LISTEN_PORT || 8080;
@@ -15,6 +16,7 @@ try {
   framework(require(functionPath), LISTEN_PORT, srv => {
     console.log('FaaS framework initialized');
     server = srv;
+    ON_DEATH(_ => { server.close(); });
   });
 } catch (err) {
   console.error(`Cannot load user function at ${functionPath}`);


### PR DESCRIPTION
This commit bumps the `@redhat/faas-js-runtime` dependency to v0.2.1. 