### PR TITLE
Bump faas js runtime dependency

### DIFF
--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,8 +10,8 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "@redhat/faas-js-runtime": "0.2.1",
-    "overload-protection": "^1.1.0"
+    "@redhat/faas-js-runtime": "0.2.2",
+    "death": "^1.1.0"
   },
   "devDependencies": {
     "supertest": "^4.0.2",

--- a/buildpacks/nodejs/runtime/server.js
+++ b/buildpacks/nodejs/runtime/server.js
@@ -6,16 +6,9 @@ const ON_DEATH = require('death')({ uncaughtException: true });
 const functionPath = process.env.FUNCTION_PATH || '../';
 const LISTEN_PORT = process.env.LISTEN_PORT || 8080;
 
-let server;
-
-module.exports.close = function close() {
-  if (server) server.close();
-};
-
 try {
-  framework(require(functionPath), LISTEN_PORT, srv => {
+  framework(require(functionPath), LISTEN_PORT, server => {
     console.log('FaaS framework initialized');
-    server = srv;
     ON_DEATH(_ => { server.close(); });
   });
 } catch (err) {


### PR DESCRIPTION
I'd like to run a new release of the buildpacks after this lands. 