### PR TITLE
fix: return failure code for failed detection

### DIFF
--- a/buildpacks/nodejs/bin/detect
+++ b/buildpacks/nodejs/bin/detect
@@ -3,6 +3,6 @@ set -eo pipefail
 
 if [[ ! -f package.json ]] ; then
   if [[ ! -f index.js ]] ; then
-    exit 1
+    exit 100
   fi
 fi

--- a/buildpacks/quarkus/bin/detect
+++ b/buildpacks/quarkus/bin/detect
@@ -7,5 +7,5 @@ dep_xpath+='/*[local-name()="dependency"]'
 dep_xpath+='/*[local-name()="artifactId" and contains(.,"quarkus-funqy")]'
 
 if ! xmllint --xpath "${dep_xpath}" pom.xml > /dev/null 2> /dev/null; then
-  exit 1
+  exit 100
 fi


### PR DESCRIPTION
It is my understanding from the [buildpacks spec](https://github.com/buildpacks/spec/blob/main/buildpack.md#detection) that a return code of 100 indicates the detection resulted in a negative detection, zero for a positive detection, and other numeric codes for exceptions/errors.  Therefore I believe these return codes should be 100.