### PR TITLE
chore: pin pack binary version at 0.13.1 in CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,10 @@ jobs:
         with:
           result-encoding: string
           script: |
-            return github.repos.getLatestRelease({
+            return github.repos.getReleaseByTag({
                 owner: "buildpacks",
-                repo: "pack"
+                repo: "pack",
+                tag: "v0.13.1"
             }).then(result => {
                 return result.data.assets
                   .filter(a => a.name.includes("linux"))


### PR DESCRIPTION
We have been bitten before by breaking changes in the pack CLI.
This commit fixes the version at 0.13.1 in CI.

Fixes: https://github.com/boson-project/buildpacks/issues/26