### PR TITLE
fix(actions): make sure checkout action pulls tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
           release-type: simple
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Determine download URL for latest pack
         id: pack-download-url


### PR DESCRIPTION
By default, the 2.x version of github's checkout action does not pull tags. Setting this configuration value forces it to.

See: https://github.com/actions/checkout/issues/338

Signed-off-by: Lance Ball <lball@redhat.com>