### PR TITLE
chore(actions): bump release please to 2.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2.1.1
+      - uses: GoogleCloudPlatform/release-please-action@v2.4.1
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should land before https://github.com/boson-project/buildpacks/pull/31

Signed-off-by: Lance Ball <lball@redhat.com>