### PR TITLE
chore(node): update faas-js-runtime with new name

### DIFF
--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "@redhat/faas-js-runtime": "0.2.2",
+    "faas-js-runtime": "0.3.0",
     "death": "^1.1.0"
   },
   "devDependencies": {

--- a/buildpacks/nodejs/runtime/server.js
+++ b/buildpacks/nodejs/runtime/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const framework = require('@redhat/faas-js-runtime');
+const framework = require('faas-js-runtime');
 const ON_DEATH = require('death')({ uncaughtException: true });
 
 const functionPath = process.env.FUNCTION_PATH || '../';


### PR DESCRIPTION
The name of the module changed from `@redhat/faas-js-runtime` to `faas-js-runtime`

Signed-off-by: Lance Ball <lball@redhat.com>