### PR TITLE
fix(deps): sync node.js builder with faas CLI

### DIFF
--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "faas-js-runtime": "0.4.0",
+    "faas-js-runtime": "0.5.1",
     "death": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@boson-project/core this is a hotfix for the dev preview release. The faas CLI templates assume faas-js-runtime >= 0.5.0 while the buildpack still installs 0.4.0. This fixes that. Given that most folks who would normally review this, I'm just going to land it and push a new release if the CI works - unless there is objection.

Signed-off-by: Lance Ball <lball@redhat.com>