### PR TITLE
fix: add --nodocs to dnf install to reduce image size

### DIFF
--- a/stacks/nodejs/build/Dockerfile
+++ b/stacks/nodejs/build/Dockerfile
@@ -8,7 +8,7 @@ LABEL io.buildpacks.stack.id=${stack_id}
 # Install Node.js and tar (needed by odo)
 USER root
 COPY ./nodejs.module /etc/dnf/modules.d
-RUN dnf install -y nodejs tar
+RUN dnf install --nodocs -y nodejs tar
 
 ENV HOME /projects/node-function
 WORKDIR $HOME

--- a/stacks/nodejs/run/Dockerfile
+++ b/stacks/nodejs/run/Dockerfile
@@ -7,7 +7,7 @@ LABEL io.buildpacks.stack.id=${stack_id}
 
 USER root
 COPY ./nodejs.module /etc/dnf/modules.d
-RUN microdnf install -y nodejs tar
+RUN microdnf install --nodocs -y nodejs tar
 
 ENV HOME /projects/node-function
 WORKDIR $HOME


### PR DESCRIPTION
This shaves about 30MB off of the run image sizes for Node.js

See: https://github.com/boson-project/buildpacks/issues/41

Signed-off-by: Lance Ball <lball@redhat.com>