### PR TITLE
ci: ensure that the build is run on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "master"
+  pull_request:
+    branches:
+      - "master"
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
For whatever reason, our CI was only running when commits landed on `master`. This change just ensures that it's run for pull requests as well. :exploding_head: 

Signed-off-by: Lance Ball <lball@redhat.com>