### PR TITLE
chore: update CI branch to use main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
I was going to cut a new release for Python, and realized that release please has not been running. I have no idea if it will pick up the changes from the Python additions. If not, we will need to create a manual release.

Signed-off-by: Lance Ball <lball@redhat.com>