### PR TITLE
fix: add signal handling to python run images

### DIFF
--- a/buildpacks/python/bin/build
+++ b/buildpacks/python/bin/build
@@ -31,5 +31,5 @@ install_or_reuse_deps ${environments_layer} ${app_layer}/requirements.txt
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]
 type = "web"
-command = "source $environments_layer/functions/bin/activate && cd $app_layer && parliament ."
+command = "source $environments_layer/functions/bin/activate && cd $app_layer && dumb-init parliament ."
 TOML

--- a/stacks/python/run/Dockerfile
+++ b/stacks/python/run/Dockerfile
@@ -7,7 +7,11 @@ LABEL io.buildpacks.stack.id=${stack_id}
 
 USER root
 COPY ./python.module /etc/dnf/modules.d
-RUN microdnf install --nodocs -y python3 tar
+RUN microdnf install --nodocs -y python3 tar wget && \
+    wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
+    chmod +x /usr/local/bin/dumb-init && \
+    microdnf remove wget tar && \
+    microdnf clean all
 
 ENV HOME /projects/python-function
 WORKDIR $HOME


### PR DESCRIPTION
This adds a signal handling proxy process that will run as PID 1 in the container.

Fixes: https://github.com/boson-project/buildpacks/issues/66

Signed-off-by: Lance Ball <lball@redhat.com>