### PR TITLE
feat: support configurable log levels for node.js functions

### DIFF
--- a/buildpacks/nodejs/runtime/server.js
+++ b/buildpacks/nodejs/runtime/server.js
@@ -5,11 +5,14 @@ const ON_DEATH = require('death')({ uncaughtException: true });
 
 const functionPath = process.env.FUNCTION_PATH || '../';
 const LISTEN_PORT = process.env.LISTEN_PORT || 8080;
+const FUNCTION_LOG_LEVEL = process.env.FUNCTION_LOG_LEVEL || 'info'
 
 try {
   framework(require(functionPath), LISTEN_PORT, server => {
     console.log('FaaS framework initialized');
     ON_DEATH(_ => { server.close(); });
+  }, {
+    logLevel: FUNCTION_LOG_LEVEL
   });
 } catch (err) {
   console.error(`Cannot load user function at ${functionPath}`);


### PR DESCRIPTION
This PR adds support for a `FUNCTION_LOG_LEVEL` environment variable. This can be used to enable the log level after this PR is merged in the Node.js FaaS runtime: https://github.com/boson-project/faas-js-runtime/pull/82/files