### PR TITLE
fix: bump nodejs faas runtime dependency for log levels

### DIFF
--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "faas-js-runtime": "0.5.1",
+    "faas-js-runtime": "0.6.0",
     "death": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Just noticed I missed this requirement in my original PR. Sorry about that @lance ! 