### PR TITLE
feat: add support for typescript projects in nodejs builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ QUARKUS_JVM_BUILDPACK_REPO := quay.io/boson/faas-quarkus-jvm-bp
 QUARKUS_NATIVE_BUILDPACK_REPO := quay.io/boson/faas-quarkus-native-bp
 SPRINGBOOT_BUILDPACK_REPO := quay.io/boson/faas-springboot-bp
 PYTHON_BUILDPACK_REPO := quay.io/boson/faas-python-bp
+TYPESCRIPT_BUILDPACK_REPO := quay.io/boson/faas-typescript-bp
 
 
 .PHONY: stacks buildpacks builders
@@ -43,6 +44,7 @@ buildpacks:
 	$(PACK_CMD) package-buildpack $(QUARKUS_NATIVE_BUILDPACK_REPO):$(VERSION_TAG) --config ./packages/quarkus-native/package.toml
 	$(PACK_CMD) package-buildpack $(SPRINGBOOT_BUILDPACK_REPO):$(VERSION_TAG) --config ./packages/springboot/package.toml
 	$(PACK_CMD) package-buildpack $(PYTHON_BUILDPACK_REPO):$(VERSION_TAG) --config ./packages/python/package.toml
+	$(PACK_CMD) package-buildpack $(TYPESCRIPT_BUILDPACK_REPO):$(VERSION_TAG) --config ./packages/typescript/package.toml
 
 builders:
 	TMP_BLDRS=$(shell mktemp -d) && \
@@ -69,7 +71,7 @@ publish:
 	    docker push $(BUILD_REPO):$$i-$(VERSION_TAG); \
 	done
 
-	for img in $(QUARKUS_NATIVE_BUILDPACK_REPO) $(QUARKUS_JVM_BUILDPACK_REPO) $(QUARKUS_NATIVE_BUILDER_REPO) $(QUARKUS_JVM_BUILDER_REPO) $(NODEJS_BUILDPACK_REPO) $(GO_BUILDPACK_REPO) $(NODEJS_BUILDER_REPO) $(GO_BUILDER_REPO) $(SPRINGBOOT_BUILDPACK_REPO) $(SPRINGBOOT_BUILDER_REPO) $(PYTHON_BUILDPACK_REPO) $(PYTHON_BUILDER_REPO); do \
+	for img in $(QUARKUS_NATIVE_BUILDPACK_REPO) $(QUARKUS_JVM_BUILDPACK_REPO) $(QUARKUS_NATIVE_BUILDER_REPO) $(QUARKUS_JVM_BUILDER_REPO) $(NODEJS_BUILDPACK_REPO) $(GO_BUILDPACK_REPO) $(NODEJS_BUILDER_REPO) $(GO_BUILDER_REPO) $(SPRINGBOOT_BUILDPACK_REPO) $(SPRINGBOOT_BUILDER_REPO) $(PYTHON_BUILDPACK_REPO) $(PYTHON_BUILDER_REPO) $(TYPESCRIPT_BUILDER_REPO); do \
 		docker push $$img:$(VERSION_TAG); \
 		if [ "$(VERSION_TAG)" != "tip" ]; then \
 		    docker tag $$img:$(VERSION_TAG) $$img:latest; \

--- a/builders/nodejs/builder.toml
+++ b/builders/nodejs/builder.toml
@@ -3,9 +3,15 @@
 id = "dev.boson.nodejs"
 image = "quay.io/boson/faas-nodejs-bp:{{VERSION}}"
 
+[[buildpacks]]
+id = "dev.boson.typescript"
+image = "quay.io/boson/faas-typescript-bp:{{VERSION}}"
+
 [[order]]
-[[order.group]]
-id = "dev.boson.nodejs"
+  [[order.group]]
+  id = "dev.boson.nodejs"
+  [[order.group]]
+  id = "dev.boson.typescript"
 
 # Stack that will be used by the builder
 [stack]

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -51,7 +51,7 @@ install_or_reuse_invoker() {
 
   echo "cache = true" > "${layer_dir}.toml"
   echo "build = true" >> "${layer_dir}.toml"
-  echo "launch = false" >> "${layer_dir}.toml"
+  echo "launch = true" >> "${layer_dir}.toml"
 }
 
 install_modules() {

--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "faas-js-runtime": "0.6.0",
+    "faas-js-runtime": "git+http://github.com/boson-project/faas-js-runtime.git#d5bfd68f4ee731f6a7170ff8978954ff8fd0c100",
     "death": "^1.1.0"
   },
   "devDependencies": {

--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "faas-js-runtime": "git+http://github.com/boson-project/faas-js-runtime.git#d5bfd68f4ee731f6a7170ff8978954ff8fd0c100",
+    "faas-js-runtime": "^0.7.0",
     "death": "^1.1.0"
   },
   "devDependencies": {

--- a/buildpacks/nodejs/runtime/package.json
+++ b/buildpacks/nodejs/runtime/package.json
@@ -10,7 +10,7 @@
     "test": "FUNCTION_PATH=./test/fixtures tape test/test.js | tap-spec"
   },
   "dependencies": {
-    "faas-js-runtime": "^0.7.0",
+    "faas-js-runtime": "^0.7.1",
     "death": "^1.1.0"
   },
   "devDependencies": {

--- a/buildpacks/typescript/bin/build
+++ b/buildpacks/typescript/bin/build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+echo "---> TypeScript Functions Buildpack"
+
+bp_dir=$(cd "$(dirname "$0")"/..; pwd)
+build_dir=$(pwd)
+layers_dir=$1
+platform_dir=$2
+
+# Make the assumption that the Node.js buildpack has already
+# installed all dependencies. All we need to do is build
+echo "---> Building project"
+npm run build
+
+cat <<TOML > "${layers_dir}/launch.toml"
+[[processes]]
+type = "web"
+command = "cd .invoker && FUNCTION_PATH=../build npm start"
+TOML

--- a/buildpacks/typescript/bin/detect
+++ b/buildpacks/typescript/bin/detect
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ ! -f tsconfig.json ]] ; then
+  exit 100
+fi

--- a/buildpacks/typescript/buildpack.toml
+++ b/buildpacks/typescript/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.2"
+
+[buildpack]
+id = "dev.boson.typescript"
+version = "0.0.1"
+name = "Typescript Function Buildpack"
+
+[[stacks]]
+id = "dev.boson.stacks.nodejs"

--- a/packages/typescript/package.toml
+++ b/packages/typescript/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "../../buildpacks/typescript"

--- a/stacks/nodejs/build/Dockerfile
+++ b/stacks/nodejs/build/Dockerfile
@@ -8,7 +8,7 @@ LABEL io.buildpacks.stack.id=${stack_id}
 # Install Node.js and tar (needed by odo)
 USER root
 COPY ./nodejs.module /etc/dnf/modules.d
-RUN dnf install --nodocs -y nodejs tar
+RUN dnf install --nodocs -y nodejs tar git
 
 ENV HOME /projects/node-function
 WORKDIR $HOME

--- a/stacks/python/build/Dockerfile
+++ b/stacks/python/build/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.buildpacks.stack.id=${stack_id}
 USER root
 ENV HOME /projects/python-function
 COPY ./python.module /etc/dnf/modules.d
-RUN dnf install --nodocs -y python3 tar
+RUN dnf install --nodocs -y python38 tar
 
 WORKDIR $HOME
 RUN chown cnb:cnb $HOME

--- a/stacks/python/build/python.module
+++ b/stacks/python/build/python.module
@@ -1,5 +1,5 @@
 [python]
 name=python
-stream=3.8
+stream=38
 profiles=
 state=enabled

--- a/stacks/python/run/Dockerfile
+++ b/stacks/python/run/Dockerfile
@@ -7,7 +7,7 @@ LABEL io.buildpacks.stack.id=${stack_id}
 
 USER root
 COPY ./python.module /etc/dnf/modules.d
-RUN microdnf install --nodocs -y python3 tar
+RUN microdnf install --nodocs -y python38 tar
 
 ENV HOME /projects/python-function
 WORKDIR $HOME

--- a/stacks/python/run/python.module
+++ b/stacks/python/run/python.module
@@ -1,5 +1,5 @@
 [python]
 name=python
-stream=3.8
+stream=38
 profiles=
 state=enabled

--- a/stacks/quarkus-native/build/Dockerfile
+++ b/stacks/quarkus-native/build/Dockerfile
@@ -23,4 +23,3 @@ ENV GRAALVM_HOME /opt/mandrel
 ENV PATH $GRAALVM_HOME/bin:$PATH
 
 USER cnb
-

--- a/stacks/ubi8-minimal/base/Dockerfile
+++ b/stacks/ubi8-minimal/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG cnb_uid=1000
 ARG cnb_gid=1001

--- a/stacks/ubi8/base/Dockerfile
+++ b/stacks/ubi8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.3
+FROM registry.access.redhat.com/ubi8/ubi:8.4
 
 ARG cnb_uid=1000
 ARG cnb_gid=1001
@@ -6,7 +6,6 @@ ARG cnb_gid=1001
 # Create user and group
 RUN groupadd -g ${cnb_gid} cnb && \
   useradd -u ${cnb_uid} -g cnb -s /bin/bash cnb
-
 # Set required CNB information
 ENV CNB_USER_ID=${cnb_uid}
 ENV CNB_GROUP_ID=${cnb_gid}


### PR DESCRIPTION
This commit adds support for TypeScript in the Node.js builder image by
providing a new typescript buildpack.

It does not create a new builder and/or stack, as it can just reuse the
Node.js stack and builder images.

These changes require a dependency on currently unreleased code in the
faas-js-runtime framework, so the Node.js and TypeScript templates have
been updated to depend on a github hash version of that for now. This will
need to change ultimately.

The dependency on a github hash required updates to the base image, since
it does not include the git binary by default. That has been added to the
base node.js build image.

Additionally, stacks have been bumped to be based on ubi[-minimal] 8.4.

Signed-off-by: Lance Ball <lball@redhat.com>