### PR TITLE
fix: use FUNC_* as environment prefix in Node apps

### DIFF
--- a/buildpacks/nodejs/runtime/server.js
+++ b/buildpacks/nodejs/runtime/server.js
@@ -5,8 +5,8 @@ const ON_DEATH  = require('death')({ uncaughtException: true });
 const code      = require(extractFullPath(process.env.FUNCTION_PATH || '../'));
 
 const options = {
-  listenPort: process.env.PORT || 8080,
-  logLevel: process.env.LOG_LEVEL || 'warn'
+  listenPort: process.env.FUNC_PORT || 8080,
+  logLevel: process.env.FUNC_LOG_LEVEL || 'warn'
 }
 
 let func;


### PR DESCRIPTION
Seehttps://github.com/boson-project/faas-js-runtime/pull/94#discussion_r636906116

Signed-off-by: Lance Ball <lball@redhat.com>