### PR TITLE
fix: make typescript optional for Node builds

### DIFF
--- a/builders/nodejs/builder.toml
+++ b/builders/nodejs/builder.toml
@@ -12,6 +12,7 @@ image = "quay.io/boson/faas-typescript-bp:{{VERSION}}"
   id = "dev.boson.nodejs"
   [[order.group]]
   id = "dev.boson.typescript"
+  optional = true
 
 # Stack that will be used by the builder
 [stack]


### PR DESCRIPTION
Makes the node builder work for node projects again.

Signed-off-by: Lance Ball <lball@redhat.com>