### PR TITLE
chore(refactor): remove duplicated code in stack dockerfiles

### DIFF
--- a/stacks/go/build/Dockerfile
+++ b/stacks/go/build/Dockerfile
@@ -8,8 +8,3 @@ LABEL io.buildpacks.stack.id=${stack_id}
 # Install Golang
 USER root
 RUN dnf install -y golang
-
-ENV HOME /projects/go-function
-WORKDIR $HOME
-RUN chown cnb:cnb $HOME
-USER cnb

--- a/stacks/go/run/Dockerfile
+++ b/stacks/go/run/Dockerfile
@@ -5,10 +5,4 @@ ARG stack_id
 ENV CNB_STACK_ID=${stack_id}
 LABEL io.buildpacks.stack.id=${stack_id}
 
-ENV HOME /projects/go-function
-WORKDIR $HOME
-USER root
-RUN chown cnb:cnb $HOME
-USER cnb
-
 ENV PORT 8080

--- a/stacks/nodejs/build/Dockerfile
+++ b/stacks/nodejs/build/Dockerfile
@@ -10,7 +10,3 @@ USER root
 COPY ./nodejs.module /etc/dnf/modules.d
 RUN dnf install --nodocs -y nodejs tar git
 
-ENV HOME /projects/node-function
-WORKDIR $HOME
-RUN chown cnb:cnb $HOME
-USER cnb

--- a/stacks/nodejs/run/Dockerfile
+++ b/stacks/nodejs/run/Dockerfile
@@ -9,11 +9,6 @@ USER root
 COPY ./nodejs.module /etc/dnf/modules.d
 RUN microdnf install --nodocs -y nodejs tar
 
-ENV HOME /projects/node-function
-WORKDIR $HOME
-RUN chown cnb:cnb $HOME
-USER cnb
-
 ENV NODE_PATH $HOME/node_modules
 ENV NODE_ENV production
 ENV PORT 8080

--- a/stacks/python/build/Dockerfile
+++ b/stacks/python/build/Dockerfile
@@ -7,10 +7,5 @@ LABEL io.buildpacks.stack.id=${stack_id}
 
 # Install Python 3, tar and a python functions virtual environment
 USER root
-ENV HOME /projects/python-function
 COPY ./python.module /etc/dnf/modules.d
 RUN dnf install --nodocs -y python38 tar
-
-WORKDIR $HOME
-RUN chown cnb:cnb $HOME
-USER cnb

--- a/stacks/python/run/Dockerfile
+++ b/stacks/python/run/Dockerfile
@@ -9,9 +9,4 @@ USER root
 COPY ./python.module /etc/dnf/modules.d
 RUN microdnf install --nodocs -y python38 tar
 
-ENV HOME /projects/python-function
-WORKDIR $HOME
-RUN chown cnb:cnb $HOME
-USER cnb
-
 ENV PORT 8080

--- a/stacks/quarkus-native/build/Dockerfile
+++ b/stacks/quarkus-native/build/Dockerfile
@@ -13,7 +13,6 @@ RUN dnf module install -y maven:3.6 \
     && dnf install -y openssl-devel wget maven tar gzip gcc glibc-static glibc-devel zlib-devel gcc-c++ \
     && dnf update -y \
     && dnf clean all -y \
-    && chown cnb:cnb $HOME \
     && wget -q -O - "https://github.com/graalvm/mandrel/releases/download/mandrel-21.0.0.0-Final/mandrel-java11-linux-amd64-21.0.0.0-Final.tar.gz" | \
         tar -xzf - -C /opt \
     && mv /opt/mandrel-java11-21.0.0.0-Final /opt/mandrel

--- a/stacks/quarkus-native/run/Dockerfile
+++ b/stacks/quarkus-native/run/Dockerfile
@@ -5,10 +5,4 @@ ARG stack_id
 ENV CNB_STACK_ID=${stack_id}
 LABEL io.buildpacks.stack.id=${stack_id}
 
-ENV HOME /projects/quarkus-function
-WORKDIR $HOME
-USER root
-RUN chown cnb:cnb $HOME
-USER cnb
-
 ENV PORT 8080

--- a/stacks/ubi8-minimal/base/Dockerfile
+++ b/stacks/ubi8-minimal/base/Dockerfile
@@ -5,10 +5,18 @@ ARG cnb_gid=1001
 
 RUN microdnf install -y shadow-utils tar
 
+ENV HOME /workspace
+
 # Create user and group
 RUN groupadd -g ${cnb_gid} cnb && \
-  useradd -u ${cnb_uid} -g cnb -s /bin/bash cnb
+  useradd -u ${cnb_uid} -g cnb -s /bin/bash cnb && \
+  mkdir ${HOME}
 
 # Set required CNB information
 ENV CNB_USER_ID=${cnb_uid}
 ENV CNB_GROUP_ID=${cnb_gid}
+
+RUN chown cnb:cnb ${HOME}
+USER cnb
+
+WORKDIR ${HOME}

--- a/stacks/ubi8/base/Dockerfile
+++ b/stacks/ubi8/base/Dockerfile
@@ -3,9 +3,17 @@ FROM registry.access.redhat.com/ubi8/ubi:8.4
 ARG cnb_uid=1000
 ARG cnb_gid=1001
 
+ENV HOME /workspace
+
 # Create user and group
 RUN groupadd -g ${cnb_gid} cnb && \
-  useradd -u ${cnb_uid} -g cnb -s /bin/bash cnb
+  useradd -u ${cnb_uid} -g cnb -s /bin/bash cnb && \
+  mkdir ${HOME}
 # Set required CNB information
 ENV CNB_USER_ID=${cnb_uid}
 ENV CNB_GROUP_ID=${cnb_gid}
+
+RUN chown cnb:cnb ${HOME}
+USER cnb
+
+WORKDIR ${HOME}


### PR DESCRIPTION
Almost all of the Dockerfiles were doing things like setting the HOME
env var to an unused directory, and configuring the cnb user. Anything
that is still needed (not unsed) and common, has been moved to the base
ubi images for the stacks.

Signed-off-by: Lance Ball <lball@redhat.com>