### PR TITLE
Add buildpack/builder/stacks for Rust

### DIFF
--- a/builders/rust/builder.toml
+++ b/builders/rust/builder.toml
@@ -1,0 +1,12 @@
+[[buildpacks]]
+id = "dev.boson.rust"
+uri = "docker://quay.io/boson/faas-rust-bp:{{VERSION}}"
+
+[[order]]
+[[order.group]]
+id = "dev.boson.rust"
+
+[stack]
+id = "dev.boson.stacks.rust"
+build-image = "quay.io/boson/faas-stack-build:rust-{{VERSION}}"
+run-image = "quay.io/boson/faas-stack-run:rust-{{VERSION}}"

--- a/buildpacks/rust/bin/build
+++ b/buildpacks/rust/bin/build
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "---> Rust Buildpack"
+
+build_dir="$(pwd)"
+bp_dir=$(cd "$(dirname "$0")"/..; pwd)
+layers_dir="$1"
+
+# TODO: fix permission error!
+cargo build --release
+
+app_layer="$layers_dir/app"
+mkdir -p "$app_layer"
+cat > "$app_layer.toml" << EOF
+launch = true
+build = false
+cache = false
+EOF
+
+cp target/release/function "$app_layer/function"
+
+cat > "$layers_dir/launch.toml" << EOF
+[[processes]]
+type = "web"
+command = "$app_layer/function"
+EOF

--- a/buildpacks/rust/bin/build
+++ b/buildpacks/rust/bin/build
@@ -3,12 +3,20 @@ set -euo pipefail
 
 echo "---> Rust Buildpack"
 
-build_dir="$(pwd)"
-bp_dir=$(cd "$(dirname "$0")"/..; pwd)
 layers_dir="$1"
 
-# TODO: fix permission error!
-cargo build --release
+deps_dir="${layers_dir}/deps"
+
+mkdir -p "${deps_dir}"
+cat <<TOML > "${deps_dir}.toml"
+launch = false
+build = true
+cache = true
+TOML
+
+target_dir="${deps_dir}/target"
+
+CARGO_HOME="${deps_dir}" cargo build --release --target-dir="${target_dir}"
 
 app_layer="$layers_dir/app"
 mkdir -p "$app_layer"
@@ -18,7 +26,7 @@ build = false
 cache = false
 EOF
 
-cp target/release/function "$app_layer/function"
+cp "${target_dir}/release/function" "${app_layer}/function"
 
 cat > "$layers_dir/launch.toml" << EOF
 [[processes]]

--- a/buildpacks/rust/bin/detect
+++ b/buildpacks/rust/bin/detect
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ ! -f Cargo.toml ]] ; then
+  exit 100
+fi

--- a/buildpacks/rust/buildpack.toml
+++ b/buildpacks/rust/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.2"
+
+[buildpack]
+id = "dev.boson.rust"
+version = "0.0.1"
+name = "Rust Function Buildpack"
+
+[[stacks]]
+id = "dev.boson.stacks.rust"

--- a/packages/rust/package.toml
+++ b/packages/rust/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "../../buildpacks/rust"

--- a/stacks/rust/build/Dockerfile
+++ b/stacks/rust/build/Dockerfile
@@ -1,0 +1,11 @@
+ARG version=tip
+FROM quay.io/boson/faas-stack-build:ubi8-${version}
+
+ARG stack_id
+ENV CNB_STACK_ID=${stack_id}
+LABEL io.buildpacks.stack.id=${stack_id}
+
+USER root
+RUN dnf install -y rust cargo
+
+USER cnb

--- a/stacks/rust/build/Dockerfile
+++ b/stacks/rust/build/Dockerfile
@@ -6,6 +6,8 @@ ENV CNB_STACK_ID=${stack_id}
 LABEL io.buildpacks.stack.id=${stack_id}
 
 USER root
-RUN dnf install -y rust cargo
+RUN dnf install -y rust cargo \
+    && dnf update -y \
+    && dnf clean all -y
 
 USER cnb

--- a/stacks/rust/run/Dockerfile
+++ b/stacks/rust/run/Dockerfile
@@ -1,0 +1,8 @@
+ARG version=tip
+FROM quay.io/boson/faas-stack-run:ubi8-minimal-${version}
+
+ARG stack_id
+ENV CNB_STACK_ID=${stack_id}
+LABEL io.buildpacks.stack.id=${stack_id}
+
+ENV PORT 8080


### PR DESCRIPTION
A pretty simple first attempt here, using the cargo/rust packages available in the Red Hat ubi repo (rustc v1.49.0)

Possible enhancements include rust version selection using `rustup` and non-linked binaries using a musl target.