### PR TITLE
refactor: remove func.yaml from all run images

### DIFF
--- a/buildpacks/go/bin/build
+++ b/buildpacks/go/bin/build
@@ -22,7 +22,8 @@ cache = false
 EOF
 
 cp $build_dir/bin/faas "$app_layer/faas"
-rm -rf $build_dir/*
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
 
 # LAUNCHER
 cat > "$layers_dir/launch.toml" << EOF

--- a/buildpacks/go/bin/build
+++ b/buildpacks/go/bin/build
@@ -22,6 +22,7 @@ cache = false
 EOF
 
 cp $build_dir/bin/faas "$app_layer/faas"
+rm -rf $build_dir/*
 
 # LAUNCHER
 cat > "$layers_dir/launch.toml" << EOF

--- a/buildpacks/nodejs/bin/build
+++ b/buildpacks/nodejs/bin/build
@@ -7,10 +7,8 @@ echo "---> Node.js Functions Buildpack"
 bp_dir=$(cd "$(dirname "$0")"/..; pwd)
 build_dir=$(pwd)
 layers_dir=$1
-platform_dir=$2
 
 source "$bp_dir/lib/build.sh"
-rm -rf "$build_dir/node_modules"
 
 install_or_reuse_tools "$layers_dir/tools"
 export PATH=$layers_dir/tools/bin:$PATH
@@ -37,8 +35,10 @@ if [ -f package.json ] ; then
 fi
 log_info "Function path ${fn_path}"
 
+install $build_dir "${layers_dir}/app"
+
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]
 type = "web"
-command = "cd .invoker && FUNCTION_PATH=${fn_path} npm start"
+command = "cd ${layers_dir}/app/.invoker && FUNCTION_PATH=${fn_path} npm start"
 TOML

--- a/buildpacks/nodejs/bin/build
+++ b/buildpacks/nodejs/bin/build
@@ -37,6 +37,10 @@ log_info "Function path ${fn_path}"
 
 install $build_dir "${layers_dir}/app"
 
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
+
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]
 type = "web"

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -15,8 +15,7 @@ install() {
   rm func.yaml
   cp -r "$build_dir"/* $layer_dir
   cp -r "$build_dir"/.invoker $layer_dir
-  rm -rf "$build_dir"/* "$build_dir"/.*
-  
+
   echo "cache = false" > "${layer_dir}.toml"
   echo "build = false" >> "${layer_dir}.toml"
   echo "launch = true" >> "${layer_dir}.toml"

--- a/buildpacks/nodejs/lib/build.sh
+++ b/buildpacks/nodejs/lib/build.sh
@@ -5,6 +5,23 @@ set -e
 bp_dir=$(cd "$(dirname "$BASH_SOURCE")"; cd ..; pwd)
 source "${bp_dir}/lib/util.sh"
 
+install() {
+  local build_dir=$1
+  local layer_dir=$2
+
+  log_info "Installing function in ${layer_dir}"
+  mkdir -p $layer_dir
+
+  rm func.yaml
+  cp -r "$build_dir"/* $layer_dir
+  cp -r "$build_dir"/.invoker $layer_dir
+  rm -rf "$build_dir"/* "$build_dir"/.*
+  
+  echo "cache = false" > "${layer_dir}.toml"
+  echo "build = false" >> "${layer_dir}.toml"
+  echo "launch = true" >> "${layer_dir}.toml"
+}
+
 install_or_reuse_tools() {
   local layer_dir=$1
   touch "${layer_dir}.toml"

--- a/buildpacks/python/bin/build
+++ b/buildpacks/python/bin/build
@@ -21,6 +21,7 @@ TOML
 # Install function
 echo "---> Installing function"
 ls -l ${build_dir}
+rm -f ${build_dir}/func.yaml
 cp -r ${build_dir}/* ${app_layer}
 
 # Install or reuse dependencies

--- a/buildpacks/python/bin/build
+++ b/buildpacks/python/bin/build
@@ -29,6 +29,10 @@ echo "---> Installing or reusing runtime dependencies"
 environments_layer="${layers_dir}/environments"
 install_or_reuse_deps ${environments_layer} ${app_layer}/requirements.txt
 
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
+
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]
 type = "web"

--- a/buildpacks/quarkus-jvm/bin/build
+++ b/buildpacks/quarkus-jvm/bin/build
@@ -36,7 +36,7 @@ TOML
 cp "${runner_jar}" "${app_layer}/app.jar"
 cp "${lib}" "${app_layer}" -r
 
-rm -fr target src pom.xml
+rm -fr target src pom.xml func.yaml
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]

--- a/buildpacks/quarkus-jvm/bin/build
+++ b/buildpacks/quarkus-jvm/bin/build
@@ -36,7 +36,9 @@ TOML
 cp "${runner_jar}" "${app_layer}/app.jar"
 cp "${lib}" "${app_layer}" -r
 
-rm -fr target src pom.xml func.yaml
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]

--- a/buildpacks/quarkus-native/bin/build
+++ b/buildpacks/quarkus-native/bin/build
@@ -33,7 +33,7 @@ cache = false
 TOML
 
 cp "${app}" "${app_layer}/application"
-rm -fr target src pom.xml
+rm -fr target src pom.xml func.yaml
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]

--- a/buildpacks/quarkus-native/bin/build
+++ b/buildpacks/quarkus-native/bin/build
@@ -33,7 +33,9 @@ cache = false
 TOML
 
 cp "${app}" "${app_layer}/application"
-rm -fr target src pom.xml func.yaml
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]

--- a/buildpacks/rust/bin/build
+++ b/buildpacks/rust/bin/build
@@ -27,6 +27,7 @@ cache = false
 EOF
 
 cp "${target_dir}/release/function" "${app_layer}/function"
+rm -f func.yaml
 
 cat > "$layers_dir/launch.toml" << EOF
 [[processes]]

--- a/buildpacks/rust/bin/build
+++ b/buildpacks/rust/bin/build
@@ -4,7 +4,7 @@ set -euo pipefail
 echo "---> Rust Buildpack"
 
 layers_dir="$1"
-
+build_dir=$(pwd)
 deps_dir="${layers_dir}/deps"
 
 mkdir -p "${deps_dir}"
@@ -27,7 +27,9 @@ cache = false
 EOF
 
 cp "${target_dir}/release/function" "${app_layer}/function"
-rm -f func.yaml
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
 
 cat > "$layers_dir/launch.toml" << EOF
 [[processes]]

--- a/buildpacks/springboot/bin/build
+++ b/buildpacks/springboot/bin/build
@@ -38,7 +38,9 @@ TOML
 
 cp "${runner_jar}" "${app_layer}/app.jar"
 
-rm -fr target src pom.xml func.yaml
+# Clean up build dir
+chmod u+w -R $build_dir
+rm -fr $build_dir/* $build_dir/.[a-z]*
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]

--- a/buildpacks/springboot/bin/build
+++ b/buildpacks/springboot/bin/build
@@ -38,7 +38,7 @@ TOML
 
 cp "${runner_jar}" "${app_layer}/app.jar"
 
-rm -fr target src pom.xml
+rm -fr target src pom.xml func.yaml
 
 cat <<TOML > "${layers_dir}/launch.toml"
 [[processes]]


### PR DESCRIPTION
This commit removes all instances of func.yaml from a built image.
In doing this, I also refactored the Node.js buildpack so that the app
is no longer running from the /workspace build directory. Instead, it's
run from a layer at /layers/app.

Fixes: https://github.com/boson-project/buildpacks/issues/87

Signed-off-by: Lance Ball <lball@redhat.com>