### PR TITLE
src: update all buildpacks to only handle functions

### DIFF
--- a/buildpacks/go/bin/detect
+++ b/buildpacks/go/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [[ ! -f go.mod ]] ; then
+if [[ ! -f func.yaml || ! -f go.mod ]] ; then
   exit 100
 fi

--- a/buildpacks/nodejs/bin/detect
+++ b/buildpacks/nodejs/bin/detect
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -eo pipefail 
 
 if [[ ! -f package.json ]] ; then
-  if [[ ! -f index.js ]] ; then
+  if [[ ! -f func.yaml || ! -f index.js ]] ; then
     exit 100
   fi
 fi

--- a/buildpacks/python/bin/detect
+++ b/buildpacks/python/bin/detect
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 if [[ ! -d __pycache__ ]] ; then
-  if [[ ! -f func.py ]] ; then
+  if [[ ! -f func.yaml || ! -f func.py ]] ; then
     exit 100
   fi
 fi

--- a/buildpacks/quarkus-jvm/bin/detect
+++ b/buildpacks/quarkus-jvm/bin/detect
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+if [[! -f func.yaml ]]; then
+  exit 100
+fi
+
 dep_xpath='/*[local-name()="project"]'
 dep_xpath+='/*[local-name()="dependencies"]'
 dep_xpath+='/*[local-name()="dependency"]'

--- a/buildpacks/quarkus-native/bin/detect
+++ b/buildpacks/quarkus-native/bin/detect
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+if [[! -f func.yaml ]]; then
+  exit 100
+fi
+
 dep_xpath='/*[local-name()="project"]'
 dep_xpath+='/*[local-name()="dependencies"]'
 dep_xpath+='/*[local-name()="dependency"]'

--- a/buildpacks/rust/bin/detect
+++ b/buildpacks/rust/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [[ ! -f Cargo.toml ]] ; then
+if [[ ! -f func.yaml || ! -f Cargo.toml ]] ; then
   exit 100
 fi

--- a/buildpacks/springboot/bin/detect
+++ b/buildpacks/springboot/bin/detect
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+if [[! -f func.yaml ]]; then
+  exit 100
+fi
+
 dep_xpath='/*[local-name()="project"]'
 dep_xpath+='/*[local-name()="dependencies"]'
 dep_xpath+='/*[local-name()="dependency"]'


### PR DESCRIPTION
Only projects containing func.yaml should evaluate as true during the buildpack detect phase.

Signed-off-by: Lance Ball <lball@redhat.com>